### PR TITLE
WIP: Erstellung von Docker Image mit mmfd, babeld, wireguard, l3roamd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+env-file

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:latest
+
+# Thanks to https://nbsoftsolutions.com/blog/routing-select-docker-containers-through-wireguard-vpn
+# use apt proxy if given as argument
+ARG APT_PROXY_PORT=
+ARG HOST_IP=
+COPY scripts /scripts
+
+RUN /scripts/detect-apt-proxy.sh $APT_PROXY_PORT && \
+apt-get update -y && \
+mkdir /mnt/config && \
+apt-get install -y software-properties-common iptables curl iproute2 ifupdown iputils-ping git apt-transport-https gnupg2 && \
+echo "deb http://deb.debian.org/debian/ unstable main" > /etc/apt/sources.list.d/unstable-wireguard.list && \
+echo "deb http://dl.ffm.freifunk.net/debian-packages/ sid main" > /etc/apt/sources.list.d/ffffm_babel.list && \
+printf 'Package: babeld \nPin: release a=sid\nPin-Priority: 150\n' > /etc/apt/preferences.d/limit-babeld_ffffm_sid && \
+printf 'Package: *\nPin: release a=unstable\nPin-Priority: 150\n' > /etc/apt/preferences.d/limit-unstable && \
+curl https://dl.ffm.freifunk.net/info@wifi-frankfurt.de.gpg.pub | apt-key add - && \
+apt-get update -y && \
+apt-get install -y wireguard babeld wg-broker l3roamd mmfd && \
+mkdir -p /etc/iproute2/rt_tables.d && \
+mkdir -p /etc/wg-broker && \
+echo "10    netz" > /etc/iproute2/rt_tables.d/babel.conf && \
+echo "11    l3roamd" >> /etc/iproute2/rt_tables.d/babel.conf && \
+echo "12    babeld" >> /etc/iproute2/rt_tables.d/babel.conf && \
+apt-get install -y strace libjson-c3
+
+
+ENTRYPOINT ["/scripts/run.sh"]
+CMD []

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 # wg-docker
-Docker Container running a Gateway with wireguard and babel
+Docker Container running a Freifunk Gateway with wireguard and babel
+
+# Building the Image
+The build can make use of an apt cache.
+```
+docker build . \
+--tag wireguard:latest \
+--build-arg APT_PROXY_PORT=3142 \
+--build-arg HOST_IP=192.168.13.9
+```
+Will start a build relying on a cache on 192.168.13.9 that is reachable on port 3142
+
+# Running a container
+
+The image will require some variables and parameters to be set in order to run:
+
+It is designed to be run like this when in interactive mode:
+```
+docker run -a stdin -a stdout -a stderr -it --rm --name wg \
+--network host \
+--cap-add=NET_ADMIN \
+--device /dev/net/tun:/dev/net/tun \
+--env-file ./env-file \
+--sysctl net.ipv6.conf.all.forwarding=1 \
+--sysctl net.ipv6.conf.all.accept_redirects=0 \
+--sysctl net.ipv4.conf.all.rp_filter=0  23b583eb83cd
+```
+
+The required settings are:
+
+* sysctls as babeld will require them: net.ipv6.conf.all.accept_redirects=0, net.ipv4.conf.all.rp_filter=0, net.ipv6.conf.all.forwarding=1
+* tun device: mmfd will require it: --device /dev/net/tun:/dev/net/tun
+* the NET_ADMIN capability is required by mmfd, l3roamd, babeld
+* The env-file specifies variables to run
+
+When running with strace, the following capabilities should be added:
+```
+ --cap-add sys_admin --cap-add sys_ptrace 
+```
+

--- a/env-file.example
+++ b/env-file.example
@@ -1,0 +1,11 @@
+DEBUG=true
+
+WGSECRET=ZGVpeGFpdGhvb1BoZWlqM2F1Nm1vb3Nob2gyYWhtYWgK
+HOST_IP=192.168.13.9
+APT_PROXY_PORT=3142
+
+WHOLENET=2a06:8187:fb00::/40 # this is the whole net-wide prefix
+NODEPREFIX=2a06:8187:fbab:1::/64 # the prefix for infrastructure. This must be in $WHOLENET
+CLIENTPREFIX=2a06:8187:fbab:2::/64 # the prefix in which the clients pick their address. This must be in $WHOLENET
+NEXTNODE=2a06:8187:fbab:2::1 # the next-node address according to site.conf
+OWNIP=fd9c:b2b9:17d8:0:61cc:7dd6:ca1c:8896 # assign this address to one of the docker hosts nic

--- a/scripts/detect-apt-proxy.sh
+++ b/scripts/detect-apt-proxy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ -z $APT_PROXY_PORT ] ; then
+  APT_PROXY_PORT=$1
+fi
+if [ -z "${HOST_IP}" ]; then
+  HOST_IP=$(route -n | awk '/^0.0.0.0/ {print $2}')
+fi
+timeout 1 bash -c 'cat < /dev/null > /dev/tcp/${HOST_IP}/${APT_PROXY_PORT}'
+if [ $? -eq 0 ]; then
+    cat > /etc/apt/apt.conf.d/30proxy <<EOL
+    Acquire::http::Proxy "http://$HOST_IP:$APT_PROXY_PORT";
+    Acquire::http::Proxy::ppa.launchpad.net DIRECT;
+EOL
+    cat /etc/apt/apt.conf.d/30proxy
+    echo "Using host's apt proxy"
+else
+    [[ -f /etc/apt/apt.conf.d/30proxy ]] && rm -f /etc/apt/apt.conf.d/30proxy
+    echo "No apt proxy detected on Docker host"
+fi

--- a/scripts/iprules
+++ b/scripts/iprules
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -x
+NODEPREFIX=$1
+CLIENTPREFIX=$2
+ip -6 rule add to $NODEPREFIX lookup 10
+ip -6 rule add to $CLIENTPREFIX lookup 10
+ip -6 rule add from $NODEPREFIX lookup 10
+ip -6 rule add from $CLIENTPREFIX lookup 10
+
+#root@gw02:/etc/wireguard# ip -6 ru s
+#0:	from all lookup local 
+#10:	from all to 2a06:8187:fbab:1:: /64 lookup netz 
+#10:	from all to 2a06:8187:fbab:2:: /64 lookup netz 
+#10:	from 2a06:8187:fbab:1::/64 lookup netz 
+#10:	from 2a06:8187:fbab:2::/64 lookup netz 
+#12:	from all to 2a06:8187:fbab:1:: /64 lookup babeld 
+#12:	from all to 2a06:8187:fbab:2:: /64 lookup babeld 
+#12:	from 2a06:8187:fbab:1::/64 lookup babeld 
+#12:	from 2a06:8187:fbab:2::/64 lookup babeld 
+#32766:	from all lookup main

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -x
+
+if [[ -z $WGSECRET ]] || [[ -z $NEXTNODE ]] || [[ -z $CLIENTPREFIX ]] ||
+  [[ -z $NODEPREFIX ]] || [[ -z $WHOLENET ]] 
+then
+  echo WGSECRET, NEXTNODE, CLIENTPREFIX, NODEPREFIX, WHOLENET must be defined. Check your env-file.
+  exit
+fi
+
+/scripts/detect-apt-proxy.sh
+
+# Install Wireguard. This has to be done dynamically since the kernel
+# module depends on the host kernel version.
+apt update
+apt install -y linux-headers-$(uname -r)
+apt install -y wireguard
+
+#setup ip rules
+/scripts/iprules $NODEPREFIX $CLIENTPREFIX
+
+
+echo $WGSECRET >/etc/wg-broker/secret
+
+#start babeld
+babeld -D  -C "ipv6-subtrees true" \
+  -C "reflect-kernel-metric true" \
+  -C "export-table 10" \
+  -C "import-table 11" \
+  -C "import-table 12" \
+  -C "local-port-readwrite 33123" \
+  -C "interface babeldummydne type wired rxcost 10 update-interval 60" \
+  -C "default enable-timestamps true" \
+  -C "default max-rtt-penalty 96" \
+  -C "default rtt-min 25" \
+  -C "out ip $NEXTNODE/128 deny" \
+  -C "redistribute ip $NEXTNODE/128 deny" \
+  -C "redistribute ip $CLIENTPREFIX eq 128  allow" \
+  -C "redistribute ip $NODEPREFIX eq 128  allow" \
+  -C "redistribute src-ip $WHOLENET ip 2000::/3 allow" \
+  -C "redistribute ip ::/0 allow" \
+  -C "redistribute ip 2000::/3 allow" \
+  -C "redistribute local deny"
+
+
+mmfd &
+/usr/local/bin/l3roamd -s /var/run/l3roamd.sock -p $NODEPREFIX -p $CLIENTPREFIX -m ens14 -m babel-vpn-1374 -t 11 -a $OWNIP -4 0:0:0:0:0:ffff::/96 &
+
+# start wireguard broker
+wg-broker-server &
+
+# Handle shutdown behavior
+finish () {
+    killall mmfd
+    killall l3roamd
+    killall babeld
+    killall wg-broker-server
+# TODO: how do we bring down all irrelevant interfaces
+    echo "$(date): Shutting down Wireguard"
+    wg-quick down $interface
+    exit 0
+}
+
+trap finish SIGTERM SIGINT SIGQUIT
+
+if [[ ! -n ${DEBUG} ]]; then
+  sleep infinity &
+  wait $!
+else
+  /bin/bash
+fi


### PR DESCRIPTION
Dieser PR ermöglicht einen Betrieb eines Freifunk-Gateways mit Wireguard in einem Docker container.
Auf dem Host muss wireguard installiert sein.
Wir haben:
* Ein runscript
* Nutzung eines Apt-Proxies sofern dieser über Umgebungsvariablen angegeben ist
* Einen Debug-Modus, der im Container eine Shell startet nachdem alle Komponenten gestartet sind

# Komponenten
* l3roamd
* wireguard
* babeld
* mmfd

# offene Punkte:
- [x] Migration der Doku in das Readme.md File
- [ ] Test 
- [x] libjson-c3 aus der Paketliste entfernen, sobald ein Release von l3roamd vorliegt welches diese Abhängigkeit korrekt im deb-Paket vermerkt. Die Codeänderung ist bereits durchgeführt.
- [ ] strace aus Paketliste entfernen, das brauchen wir nur zu Beginn für Analysen wenn mal was nicht geht.
- [x] l3roamd: https://github.com/freifunk-gluon/l3roamd/issues/51
- [x] wg-broker: https://github.com/christf/wg-broker/issues/2
- [x] wg-broker: https://github.com/christf/wg-broker/issues/1