### PR TITLE
Remove forbidden arguments from docker call

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ docker run -a stdin -a stdout -a stderr -it --rm --name wg \
 --device /dev/net/tun:/dev/net/tun \
 --env-file ./env-file \
 --privileged \
---sysctl net.ipv6.conf.all.forwarding=1 \
---sysctl net.ipv6.conf.all.accept_redirects=0 \
---sysctl net.ipv4.conf.all.rp_filter=0 ffmd/wg-docker
+ffmd/wg-docker
 ```
 
 The required settings are:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ ffmd/wg-docker
 
 The required settings are:
 
-* sysctls as babeld will require them: net.ipv6.conf.all.accept_redirects=0, net.ipv4.conf.all.rp_filter=0, net.ipv6.conf.all.forwarding=1
+* sysctls as babeld will require them:
+  * `net.ipv6.conf.all.accept_redirects=0`
+  * `net.ipv4.conf.all.rp_filter=0`
+  * `net.ipv6.conf.all.forwarding=1`
 * tun device: l3roamd and mmfd will require it: \
   --device /dev/net/tun:/dev/net/tun
 * the NET_ADMIN capability is required by mmfd, l3roamd, babeld


### PR DESCRIPTION
Setup for the host network from inside a container is no longer allowed.