### PR TITLE
Add GitHub workflows for release and docker build

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -1,0 +1,39 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: "Create release"
+    runs-on: ubuntu-22.04
+    steps:
+      - name: "Check-out"
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: "Generate release changelog"
+        id: generate-release-changelog
+        uses: heinrichreimer/github-changelog-generator-action@v2.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          onlyLastTag: "true" # set to false if no tags exist (buggy with only one tag)
+          stripHeaders: "true"
+          stripGeneratorNotice: "true"
+
+      - name: Extract the VERSION name
+        id: get-version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+
+      - name: "Create GitHub release"
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref }}
+          name: "${{ steps.get-version.outputs.VERSION }}"
+          body: "${{ steps.generate-release-changelog.outputs.changelog }}"
+          prerelease: ${{ startsWith(steps.get-version.outputs.VERSION, 'v0.') }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: True

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,53 @@
+name: Docker Image
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - 'master'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ffmd/wg-docker
+          tags: |
+            # 1.2.3
+            type=semver,pattern={{version}}
+            # disabled if major zero
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            # generate lates from default branch
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Docker Container running a Freifunk Gateway. It contains the following component
 
 An image can be pulled from dockerhub:
 ```
-docker pull klausdieter371/wg-docker
+docker pull ffmd/wg-docker
 ```
 
 # Building the Image
@@ -34,7 +34,7 @@ docker run -a stdin -a stdout -a stderr -it --rm --name wg \
 --privileged \
 --sysctl net.ipv6.conf.all.forwarding=1 \
 --sysctl net.ipv6.conf.all.accept_redirects=0 \
---sysctl net.ipv4.conf.all.rp_filter=0 klausdieter371/wg-docker
+--sysctl net.ipv4.conf.all.rp_filter=0 ffmd/wg-docker
 ```
 
 The required settings are:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,12 +1,12 @@
 version: "3"
 services:
   wg:
-    image: klausdieter371/wg-docker
+    image: ffmd/wg-docker
     network_mode: "host"
     privileged: true
-    cap_add: 
+    cap_add:
       - NET_ADMIN
-    devices: 
+    devices:
       - /dev/net/tun:/dev/net/tun
     sysctls:
       - net.ipv6.conf.all.forwarding=1


### PR DESCRIPTION
There is no concept for releases yet, as the container builds software from `master` branches, but a release action is prepared just in case.

For now, we will most likely end up with docker image builds for `latest`.